### PR TITLE
Make sure voices get re-scheduled at the right time

### DIFF
--- a/public/player.js
+++ b/public/player.js
@@ -289,8 +289,6 @@ async function refreshAudioSources({ reset } = { reset: false }) {
   // Remove sources that should no longer be there
   Object.keys(audioSources).filter(id => audioSources[id]).forEach(id => {
     if (reset || !selectedSources[id]) {
-      console.log(id, 'remove', audioSources[id].segment, 'current', currentSegment);
-      audioSources[id].node.stop();
       audioSources[id].nodes.forEach(node => node.disconnect());
       audioSources[id].gainNode.disconnect();
       audioSources[id].pannerNode.disconnect();


### PR DESCRIPTION
Voice recordings may be slightly too long or slightly too short. Looping using the Web Audio API won't work for them since looping will take place as soon as the recording is over, meaning too early or too late.

This update makes the code use two alternating instances of buffer nodes for each voice (using two to give time to reschedule the next "play").

Note that the Web Audio API cannot re-play a buffer source that has ended, so a new node gets re-created each time.