### PR TITLE
[Recorder] Take latest recorded chunks into account

### DIFF
--- a/public/recorder.js
+++ b/public/recorder.js
@@ -121,7 +121,7 @@ recordBtn.addEventListener("click", async () => {
   recordedChunks = [];
   recorder.ondataavailable = event => recordedChunks.push(event.data);
   recorder.onstop = () => {
-    // Allow user to listent to and upload resulting recording
+    // Allow user to listen to and upload resulting recording
     recording = new Blob(recordedChunks);
     [...form.querySelectorAll("input,button,select")].forEach(n => n.disabled = false);
     document.getElementById("uploader").classList.remove("disabled");

--- a/public/recorder.js
+++ b/public/recorder.js
@@ -120,6 +120,12 @@ recordBtn.addEventListener("click", async () => {
   recorder = new MediaRecorder(stream, {mimeType: "audio/webm"});
   recordedChunks = [];
   recorder.ondataavailable = event => recordedChunks.push(event.data);
+  recorder.onstop = () => {
+    // Allow user to listent to and upload resulting recording
+    recording = new Blob(recordedChunks);
+    [...form.querySelectorAll("input,button,select")].forEach(n => n.disabled = false);
+    document.getElementById("uploader").classList.remove("disabled");
+  }
   tone.play();
   for (i = 3; i > 0; i--) {
     if (i == 1) {
@@ -154,10 +160,7 @@ ref.addEventListener("ended", () => {
     recordBtn.disabled = false;
     recordBtn.textContent = "Re-record";
     replayBtn.disabled = false;
-    // Upload resulting recording
-    recording = new Blob(recordedChunks);
-    [...form.querySelectorAll("input,button,select")].forEach(n => n.disabled = false);
-    document.getElementById("uploader").classList.remove("disabled");
+    onAir = false;
   }
 });
 


### PR DESCRIPTION
Recorded chunks are not directly available after calling stop() on the MediaStream recorder: they are available once all the `dataavailable` events have been processed. This update rather connects to the `stop` event of the recorder, which is guaranteed to be fired after all `dataavailable` events.